### PR TITLE
Feature/jsonutils checkparams

### DIFF
--- a/src/main/java/io/grisu/pojo/utils/JSONUtils.java
+++ b/src/main/java/io/grisu/pojo/utils/JSONUtils.java
@@ -71,10 +71,9 @@ public class JSONUtils {
          final List<Object> params = jsonMapper.readValue(bytes, List.class);
 
          if (params.size() != types.length) {
-             throw new IllegalArgumentException(
-                 format(
-                     "Wrong parameters size. Requested = %d, actual = %d",
-                     types.length, params.size()));
+            throw new IllegalArgumentException(format(
+                "Wrong parameters size. Requested = %d, actual = %d",
+                types.length, params.size()));
          }
 
          for (int i = 0; i < types.length; i++) {

--- a/src/main/java/io/grisu/pojo/utils/JSONUtils.java
+++ b/src/main/java/io/grisu/pojo/utils/JSONUtils.java
@@ -71,7 +71,10 @@ public class JSONUtils {
          final List<Object> params = jsonMapper.readValue(bytes, List.class);
 
          if (params.size() != types.length) {
-            throw new IllegalArgumentException(format("Wrong parameters size. Requested = %d, actual = %d", types.length, params.size()));
+             throw new IllegalArgumentException(
+                 format(
+                     "Wrong parameters size. Requested = %d, actual = %d",
+                     types.length, params.size()));
          }
 
          for (int i = 0; i < types.length; i++) {

--- a/src/main/java/io/grisu/pojo/utils/JSONUtils.java
+++ b/src/main/java/io/grisu/pojo/utils/JSONUtils.java
@@ -14,6 +14,8 @@ import io.grisu.pojo.Pojo;
 import io.grisu.pojo.serializer.MapToPojo;
 import io.grisu.pojo.serializer.PojoToMap;
 
+import static java.lang.String.format;
+
 public class JSONUtils {
 
    protected static final ObjectMapper jsonMapper;
@@ -67,6 +69,11 @@ public class JSONUtils {
 
       try {
          final List<Object> params = jsonMapper.readValue(bytes, List.class);
+
+         if (params.size() != types.length) {
+            throw new IllegalArgumentException(format("Wrong parameters size. Requested = %d, actual = %d", types.length, params.size()));
+         }
+
          for (int i = 0; i < types.length; i++) {
             final Object o = MapToPojo.convert(params.get(i), types[i]);
             outList.add(o);

--- a/src/test/java/io/grisu/pojo/utils/JSONUtilsTests.java
+++ b/src/test/java/io/grisu/pojo/utils/JSONUtilsTests.java
@@ -1,11 +1,13 @@
 package io.grisu.pojo.utils;
 
+import java.lang.reflect.Type;
 import java.util.*;
 
 import io.grisu.pojo.supportingclasses.NodeSubType;
 import io.grisu.pojo.supportingclasses.PagedResult;
 import io.grisu.pojo.supportingclasses.ParameterizedPojo;
 import io.grisu.pojo.supportingclasses.TestPojo;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -151,4 +153,19 @@ public class JSONUtilsTests {
       assertTrue(((Set) decodedParams[7]).contains("str3"));
    }
 
+   @Test(expected = IllegalArgumentException.class)
+   public void decodeAsParamsShouldCheckSignature_1() {
+      JSONUtils.decodeAsParams(
+          "[\"aaa\", \"bbb\", \"ccc\"]".getBytes(),
+          new Type[] {String.class, String.class}
+      );
+   }
+
+   @Test(expected = IllegalArgumentException.class)
+   public void decodeAsParamsShouldCheckSignature_2() {
+      JSONUtils.decodeAsParams(
+          "[\"aaa\", \"bbb\"]".getBytes(),
+          new Type[] {String.class, String.class, String.class}
+      );
+   }
 }


### PR DESCRIPTION
 JSONUtils.decodeAsParams() should check compliant param signature

List of params and types should be of same length, otherwise throw
IllegalArgumentException